### PR TITLE
[Feat] 질문 보내기 기능, 화면에 바로 반영

### DIFF
--- a/src/components/organisms/Modal/Modal.jsx
+++ b/src/components/organisms/Modal/Modal.jsx
@@ -15,18 +15,14 @@ import requestApi from '../../../utils/requestApi';
  */
 export default function Modal({ toggleModal, imageSource, name, id }) {
   const [inputQuestion, setInputQuestion] = useState('');
-  // TODO[이시열] : AnswerForm에 질문보내기 api 요청 handler 전달, QuestionPage에서 질문 대상 객체 전달받기
+
   const questionContent = {
     content: inputQuestion,
   };
 
-  const handleQuestionSubmit = () => {
-    const result = requestApi(
-      `subjects/${id}/questions/`,
-      'post',
-      questionContent,
-    );
-    console.log(result);
+  const handleQuestionSubmit = async () => {
+    await requestApi(`subjects/${id}/questions/`, 'post', questionContent);
+    toggleModal();
   };
 
   const height = useResizeModal();

--- a/src/components/organisms/Modal/Modal.jsx
+++ b/src/components/organisms/Modal/Modal.jsx
@@ -12,7 +12,7 @@ import useResizeModal from './useResizeModal.hook';
  * @param {function} props.toggleModal - 모달을 토글하는 함수
  * @returns 모달 컴포넌트를 반환
  */
-export default function Modal({ subject, toggleModal }) {
+export default function Modal({ toggleModal, imageSource, name }) {
   const [inputQuestion, setInputQuestion] = useState('');
   // TODO[이시열] : AnswerForm에 질문보내기 api 요청 handler 전달, QuestionPage에서 질문 대상 객체 전달받기
 
@@ -36,8 +36,8 @@ export default function Modal({ subject, toggleModal }) {
         <QuestionBox>
           <RecipientBox>
             <Text>To.</Text>
-            <UserProfileImage type="questionModal" />
-            <Recipient>{subject.name}</Recipient>
+            <UserProfileImage type="questionModal" imageSource={imageSource} />
+            <Recipient>{name}</Recipient>
           </RecipientBox>
           <AnswerForm
             inputValue={inputQuestion}

--- a/src/components/organisms/Modal/Modal.jsx
+++ b/src/components/organisms/Modal/Modal.jsx
@@ -4,6 +4,7 @@ import imageData from '../../../assets/imageData';
 import UserProfileImage from '../../atoms/UserProfileImage/UserProfileImage';
 import AnswerForm from '../AnswerForm/AnswerForm';
 import useResizeModal from './useResizeModal.hook';
+import requestApi from '../../../utils/requestApi';
 
 /**
  * 모달 컴포넌트
@@ -12,9 +13,21 @@ import useResizeModal from './useResizeModal.hook';
  * @param {function} props.toggleModal - 모달을 토글하는 함수
  * @returns 모달 컴포넌트를 반환
  */
-export default function Modal({ toggleModal, imageSource, name }) {
+export default function Modal({ toggleModal, imageSource, name, id }) {
   const [inputQuestion, setInputQuestion] = useState('');
   // TODO[이시열] : AnswerForm에 질문보내기 api 요청 handler 전달, QuestionPage에서 질문 대상 객체 전달받기
+  const questionContent = {
+    content: inputQuestion,
+  };
+
+  const handleQuestionSubmit = () => {
+    const result = requestApi(
+      `subjects/${id}/questions/`,
+      'post',
+      questionContent,
+    );
+    console.log(result);
+  };
 
   const height = useResizeModal();
 
@@ -42,6 +55,7 @@ export default function Modal({ toggleModal, imageSource, name }) {
           <AnswerForm
             inputValue={inputQuestion}
             setInputValue={setInputQuestion}
+            onClick={handleQuestionSubmit}
             placeholder="질문을 입력해주세요"
             buttonText="질문 보내기"
             inputAreaHeight={height}

--- a/src/components/organisms/QuestionsFeedCard/QuestionsFeedCard.jsx
+++ b/src/components/organisms/QuestionsFeedCard/QuestionsFeedCard.jsx
@@ -46,10 +46,14 @@ const Wrapper = styled.div`
   flex-direction: column;
   padding: 32px;
   max-width: 684px;
-  gap: 24px 0;
+  gap: 32px;
   border-radius: 16px;
   box-shadow: 0px 4px 4px 0px rgba(140, 140, 140, 0.25);
   background-color: var(--Grayscale-10);
+  @media (max-width: 767px) {
+    padding: 24px;
+    gap: 24px;
+  }
 `;
 
 const QuestionBox = styled.section`

--- a/src/components/pages/MainPage.jsx
+++ b/src/components/pages/MainPage.jsx
@@ -65,7 +65,7 @@ const StyledGoToAnswerButton = styled(GoToAnswerButton)`
   }
 `;
 const MainPageImage = styled.img`
-  position: absolute;
+  position: fixed;
   width: 100%;
   top: 205px;
   @media (max-width: 1199px) {

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -1,10 +1,11 @@
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { useEffect, useState } from 'react';
+import useQuestionData from '../../hooks/useQuestionData';
 import useRequestApi from '../../hooks/useRequestApi';
 import FloatingButton from '../atoms/Button/FloatingButton/FloatingButton';
-import Modal from '../organisms/Modal/Modal';
 import FeedCardList from '../organisms/FeedCardList/FeedCardList';
+import Modal from '../organisms/Modal/Modal';
 import TopPanel from '../organisms/TopPanel/TopPanel';
 
 // Todo (송상훈) 좋아요 싫어요 로직구현, 무한스크롤 구현
@@ -15,12 +16,7 @@ export default function QuestionPage() {
   const imageSource = ownerData?.imageSource;
   const name = ownerData?.name;
 
-  const { data: questionsData } = useRequestApi(
-    `subjects/${id}/questions/?limit=5&offset=0`,
-    'get',
-  );
-  const count = questionsData?.count || 0;
-  const questions = questionsData?.results || [];
+  const { count, questions } = useQuestionData();
 
   const [isModalClicked, setIsModalClicked] = useState(false);
   const toggleModal = () => {

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -59,7 +59,13 @@ export default function QuestionPage() {
           </FloatingButton>
         </ButtonSection>
       </Wrapper>
-      {isModalClicked ? <Modal toggleModal={toggleModal} /> : null}
+      {isModalClicked ? (
+        <Modal
+          toggleModal={toggleModal}
+          imageSource={imageSource}
+          name={name}
+        />
+      ) : null}
     </>
   );
 }

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import useQuestionData from '../../hooks/useQuestionData';
 import FloatingButton from '../atoms/Button/FloatingButton/FloatingButton';
@@ -6,29 +5,13 @@ import FeedCardList from '../organisms/FeedCardList/FeedCardList';
 import Modal from '../organisms/Modal/Modal';
 import TopPanel from '../organisms/TopPanel/TopPanel';
 import useQuestionOwnerData from '../../hooks/useQuestionOwnerData';
+import useToggle from '../../hooks/useToggle';
 
 // Todo (송상훈) 좋아요 싫어요 로직구현, 무한스크롤 구현
 export default function QuestionPage() {
   const { imageSource, name, id } = useQuestionOwnerData();
   const { count, questions } = useQuestionData();
-
-  const [isModalClicked, setIsModalClicked] = useState(false);
-  const toggleModal = () => {
-    setIsModalClicked((prev) => !prev);
-  };
-
-  // 스크롤바 영역 보존
-  document.documentElement.style.scrollbarGutter = 'stable';
-
-  // 모달창이 띄워지면 스크롤 방지
-  useEffect(() => {
-    if (isModalClicked) {
-      document.body.style.overflow = 'hidden';
-    }
-    return () => {
-      document.body.style.overflow = 'unset';
-    };
-  }, [isModalClicked]);
+  const [isModalClicked, toggleModal] = useToggle();
 
   return (
     <>

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -1,21 +1,15 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import useQuestionData from '../../hooks/useQuestionData';
-import useRequestApi from '../../hooks/useRequestApi';
 import FloatingButton from '../atoms/Button/FloatingButton/FloatingButton';
 import FeedCardList from '../organisms/FeedCardList/FeedCardList';
 import Modal from '../organisms/Modal/Modal';
 import TopPanel from '../organisms/TopPanel/TopPanel';
+import useQuestionOwnerData from '../../hooks/useQuestionOwnerData';
 
 // Todo (송상훈) 좋아요 싫어요 로직구현, 무한스크롤 구현
 export default function QuestionPage() {
-  const { id } = useParams();
-
-  const { data: ownerData } = useRequestApi(`subjects/${id}/`, 'get');
-  const imageSource = ownerData?.imageSource;
-  const name = ownerData?.name;
-
+  const { imageSource, name, id } = useQuestionOwnerData();
   const { count, questions } = useQuestionData();
 
   const [isModalClicked, setIsModalClicked] = useState(false);

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -64,6 +64,7 @@ export default function QuestionPage() {
           toggleModal={toggleModal}
           imageSource={imageSource}
           name={name}
+          id={id}
         />
       ) : null}
     </>

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -1,17 +1,20 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 import useQuestionData from '../../hooks/useQuestionData';
+import useQuestionOwnerData from '../../hooks/useQuestionOwnerData';
+import useToggle from '../../hooks/useToggle';
 import FloatingButton from '../atoms/Button/FloatingButton/FloatingButton';
 import FeedCardList from '../organisms/FeedCardList/FeedCardList';
 import Modal from '../organisms/Modal/Modal';
 import TopPanel from '../organisms/TopPanel/TopPanel';
-import useQuestionOwnerData from '../../hooks/useQuestionOwnerData';
-import useToggle from '../../hooks/useToggle';
 
 // Todo (송상훈) 좋아요 싫어요 로직구현, 무한스크롤 구현
 export default function QuestionPage() {
+  const [isModalClicked, setIsModalClicked] = useState(false);
   const { imageSource, name, id } = useQuestionOwnerData();
-  const { count, questions } = useQuestionData();
-  const [isModalClicked, toggleModal] = useToggle();
+  const { count, questions } = useQuestionData(isModalClicked);
+
+  const toggleModal = useToggle(isModalClicked, setIsModalClicked);
 
   return (
     <>

--- a/src/hooks/useQuestionData.jsx
+++ b/src/hooks/useQuestionData.jsx
@@ -1,0 +1,17 @@
+import { useParams } from 'react-router-dom';
+import useRequestApi from './useRequestApi';
+
+const useQuestionData = () => {
+  const { id } = useParams();
+
+  const { data: questionsData } = useRequestApi(
+    `subjects/${id}/questions/?limit=5&offset=0`,
+    'get',
+  );
+  const count = questionsData?.count || 0;
+  const questions = questionsData?.results || [];
+
+  return { count, questions };
+};
+
+export default useQuestionData;

--- a/src/hooks/useQuestionData.jsx
+++ b/src/hooks/useQuestionData.jsx
@@ -1,15 +1,30 @@
 import { useParams } from 'react-router-dom';
-import useRequestApi from './useRequestApi';
+import { useEffect, useState } from 'react';
+import requestApi from '../utils/requestApi';
 
-const useQuestionData = () => {
+/**
+ * 질문 대상에게 작성된 질문의 갯수와 질문들을 반환,
+ * 질문을 보내면 isModalClicked 상태가 바뀌어 QuestionPage 재렌더링
+ * @param {boolean} isModalClicked 모달창이 띄워져 있는지 여부
+ * @returns count, questions
+ */
+const useQuestionData = (isModalClicked) => {
   const { id } = useParams();
+  const [count, setCount] = useState(0);
+  const [questions, setQuestions] = useState([]);
 
-  const { data: questionsData } = useRequestApi(
-    `subjects/${id}/questions/?limit=5&offset=0`,
-    'get',
-  );
-  const count = questionsData?.count || 0;
-  const questions = questionsData?.results || [];
+  useEffect(() => {
+    const getData = async () => {
+      const questionsData = await requestApi(
+        `subjects/${id}/questions/?limit=5&offset=0`,
+        'get',
+      );
+      setCount(questionsData?.count || 0);
+      setQuestions(questionsData?.results || []);
+    };
+
+    getData();
+  }, [isModalClicked]);
 
   return { count, questions };
 };

--- a/src/hooks/useQuestionOwnerData.jsx
+++ b/src/hooks/useQuestionOwnerData.jsx
@@ -1,6 +1,10 @@
 import { useParams } from 'react-router-dom';
 import useRequestApi from './useRequestApi';
 
+/**
+ * 질문 대상의 이미지, 이름, id를 반환하는 훅
+ * @returns imageSource, name, id
+ */
 const useQuestionOwnerData = () => {
   const { id } = useParams();
 

--- a/src/hooks/useQuestionOwnerData.jsx
+++ b/src/hooks/useQuestionOwnerData.jsx
@@ -1,0 +1,14 @@
+import { useParams } from 'react-router-dom';
+import useRequestApi from './useRequestApi';
+
+const useQuestionOwnerData = () => {
+  const { id } = useParams();
+
+  const { data: ownerData } = useRequestApi(`subjects/${id}/`, 'get');
+  const imageSource = ownerData?.imageSource;
+  const name = ownerData?.name;
+
+  return { imageSource, name, id };
+};
+
+export default useQuestionOwnerData;

--- a/src/hooks/useToggle.jsx
+++ b/src/hooks/useToggle.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+const useToggle = () => {
+  const [isModalClicked, setIsModalClicked] = useState(false);
+  const toggleModal = () => {
+    setIsModalClicked((prev) => !prev);
+  };
+
+  // 스크롤바 영역 보존
+  document.documentElement.style.scrollbarGutter = 'stable';
+
+  // 모달창이 띄워지면 스크롤 방지
+  useEffect(() => {
+    if (isModalClicked) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [isModalClicked]);
+
+  return [isModalClicked, toggleModal];
+};
+
+export default useToggle;

--- a/src/hooks/useToggle.jsx
+++ b/src/hooks/useToggle.jsx
@@ -1,11 +1,15 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
-const useToggle = () => {
-  const [isModalClicked, setIsModalClicked] = useState(false);
+/**
+ * 모달창이 띄워지면 스크롤 방지, 토글 함수 반환
+ * @param {boolean} isModalClicked 모달창이 띄워져 있는지 여부
+ * @param {function} setIsModalClicked isModalClicked 상태 변경 함수
+ * @returns {function} toggleModal
+ */
+const useToggle = (isModalClicked, setIsModalClicked) => {
   const toggleModal = () => {
     setIsModalClicked((prev) => !prev);
   };
-
   // 스크롤바 영역 보존
   document.documentElement.style.scrollbarGutter = 'stable';
 
@@ -19,7 +23,7 @@ const useToggle = () => {
     };
   }, [isModalClicked]);
 
-  return [isModalClicked, toggleModal];
+  return toggleModal;
 };
 
 export default useToggle;


### PR DESCRIPTION
## 주요 변경사항
- QuestionPage에서 질문 대상의 데이터와 질문을 받아오는 로직을 커스텀 훅으로 분리 - QuestionPage가 복잡해져서 한번 분리해봤습니당
  - useQuestionOwnerData, useQuestionData 
- useToggle 훅으로 분리
- 질문 보내기 모달창에서 질문을 작성하고 보내면, 모달창 닫히고 QuestionPage 재렌더링 - 생성된 질문 반영
- 이상한 부분 있으면 말씀해주세용
  
 