### PR TITLE
:lipstick: FeatQuestionPage 무한스크롤 기능 구현

### DIFF
--- a/src/components/organisms/Modal/Modal.jsx
+++ b/src/components/organisms/Modal/Modal.jsx
@@ -13,7 +13,14 @@ import requestApi from '../../../utils/requestApi';
  * @param {function} props.toggleModal - 모달을 토글하는 함수
  * @returns 모달 컴포넌트를 반환
  */
-export default function Modal({ toggleModal, imageSource, name, id }) {
+export default function Modal({
+  toggleModal,
+  imageSource,
+  name,
+  id,
+  setCount,
+  setQuestions,
+}) {
   const [inputQuestion, setInputQuestion] = useState('');
 
   const questionContent = {
@@ -21,7 +28,20 @@ export default function Modal({ toggleModal, imageSource, name, id }) {
   };
 
   const handleQuestionSubmit = async () => {
-    await requestApi(`subjects/${id}/questions/`, 'post', questionContent);
+    const newQuestion = await requestApi(
+      `subjects/${id}/questions/`,
+      'post',
+      questionContent,
+    );
+    setCount((prevCount) => prevCount + 1);
+
+    setQuestions((prevQuestions) => {
+      if (prevQuestions.length === 0) {
+        return [newQuestion];
+      }
+      return [newQuestion, ...prevQuestions];
+    });
+
     toggleModal();
   };
 

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import useQuestionData from '../../hooks/useQuestionData';
 import useQuestionOwnerData from '../../hooks/useQuestionOwnerData';
@@ -8,13 +8,34 @@ import FeedCardList from '../organisms/FeedCardList/FeedCardList';
 import Modal from '../organisms/Modal/Modal';
 import TopPanel from '../organisms/TopPanel/TopPanel';
 
-// Todo (송상훈) 좋아요 싫어요 로직구현, 무한스크롤 구현
+/**
+ * @returns QuestionPage
+ */
+
 export default function QuestionPage() {
   const [isModalClicked, setIsModalClicked] = useState(false);
+  const [offset, setOffset] = useState(0);
   const { imageSource, name, id } = useQuestionOwnerData();
-  const { count, questions } = useQuestionData(isModalClicked);
+  const { count, questions } = useQuestionData(isModalClicked, offset);
 
   const toggleModal = useToggle(isModalClicked, setIsModalClicked);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } =
+        document.documentElement;
+
+      if (scrollTop + clientHeight >= scrollHeight - 1) {
+        setOffset((prevOffset) => prevOffset + 8);
+      }
+    };
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   return (
     <>

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -44,6 +44,11 @@ export default function QuestionPage() {
     <>
       <TopPanel name={name} imageSource={imageSource} />
       <Wrapper>
+        <ButtonSection>
+          <FloatingButton toggleModal={toggleModal}>
+            질문 작성하기
+          </FloatingButton>
+        </ButtonSection>
         <FeedCard>
           <FeedCardList
             type="question"
@@ -53,11 +58,6 @@ export default function QuestionPage() {
             imageSource={imageSource}
           />
         </FeedCard>
-        <ButtonSection>
-          <FloatingButton toggleModal={toggleModal}>
-            질문 작성하기
-          </FloatingButton>
-        </ButtonSection>
       </Wrapper>
       {isModalClicked ? (
         <Modal
@@ -86,9 +86,10 @@ const FeedCard = styled.div`
   flex-direction: column;
   align-items: center;
 
-  margin: 54px 32px 0;
+  margin: 9px 32px 0;
 `;
 
 const ButtonSection = styled.div`
-  position: absolute;
+  margin-left: auto;
+  margin-right: 32px;
 `;

--- a/src/components/pages/QuestionPage.jsx
+++ b/src/components/pages/QuestionPage.jsx
@@ -15,10 +15,13 @@ import TopPanel from '../organisms/TopPanel/TopPanel';
 export default function QuestionPage() {
   const [isModalClicked, setIsModalClicked] = useState(false);
   const [offset, setOffset] = useState(0);
+  const [count, setCount] = useState(0);
+  const [questions, setQuestions] = useState([]);
   const { imageSource, name, id } = useQuestionOwnerData();
-  const { count, questions } = useQuestionData(isModalClicked, offset);
 
   const toggleModal = useToggle(isModalClicked, setIsModalClicked);
+
+  useQuestionData(offset, setCount, setQuestions);
 
   useEffect(() => {
     const handleScroll = () => {
@@ -62,6 +65,8 @@ export default function QuestionPage() {
           imageSource={imageSource}
           name={name}
           id={id}
+          setCount={setCount}
+          setQuestions={setQuestions}
         />
       ) : null}
     </>
@@ -85,5 +90,5 @@ const FeedCard = styled.div`
 `;
 
 const ButtonSection = styled.div`
-  margin: 54px 32px 32px auto;
+  position: absolute;
 `;

--- a/src/hooks/useQuestionData.jsx
+++ b/src/hooks/useQuestionData.jsx
@@ -40,8 +40,6 @@ const useQuestionData = (offset, setCount, setQuestions) => {
 
     getData();
   }, [offset]);
-
-  return { setCount, setQuestions };
 };
 
 export default useQuestionData;

--- a/src/hooks/useQuestionData.jsx
+++ b/src/hooks/useQuestionData.jsx
@@ -8,12 +8,11 @@ import requestApi from '../utils/requestApi';
  * @param {boolean} isModalClicked 모달창이 띄워져 있는지 여부
  * @returns count, questions
  */
-const useQuestionData = (isModalClicked, offset) => {
+const useQuestionData = (offset, setCount, setQuestions) => {
   const limit = 8;
 
   const { id } = useParams();
-  const [count, setCount] = useState(0);
-  const [questions, setQuestions] = useState([]);
+
   const [hasNext, setHasNext] = useState(true);
 
   useEffect(() => {
@@ -40,9 +39,9 @@ const useQuestionData = (isModalClicked, offset) => {
     };
 
     getData();
-  }, [isModalClicked, offset]);
+  }, [offset]);
 
-  return { count, questions };
+  return { setCount, setQuestions };
 };
 
 export default useQuestionData;

--- a/src/hooks/useQuestionData.jsx
+++ b/src/hooks/useQuestionData.jsx
@@ -8,23 +8,39 @@ import requestApi from '../utils/requestApi';
  * @param {boolean} isModalClicked 모달창이 띄워져 있는지 여부
  * @returns count, questions
  */
-const useQuestionData = (isModalClicked) => {
+const useQuestionData = (isModalClicked, offset) => {
+  const limit = 8;
+
   const { id } = useParams();
   const [count, setCount] = useState(0);
   const [questions, setQuestions] = useState([]);
+  const [hasNext, setHasNext] = useState(true);
 
   useEffect(() => {
+    if (!hasNext) return;
+
     const getData = async () => {
       const questionsData = await requestApi(
-        `subjects/${id}/questions/?limit=8&offset=0`,
+        `subjects/${id}/questions/?limit=${limit}&offset=${offset}`,
         'get',
       );
       setCount(questionsData?.count || 0);
-      setQuestions(questionsData?.results || []);
+      if (offset === 0) {
+        setQuestions(questionsData?.results || []);
+      } else {
+        setQuestions((prevQuestions) => [
+          ...prevQuestions,
+          ...(questionsData?.results || []),
+        ]);
+
+        if (!questionsData?.next) {
+          setHasNext(false);
+        }
+      }
     };
 
     getData();
-  }, [isModalClicked]);
+  }, [isModalClicked, offset]);
 
   return { count, questions };
 };


### PR DESCRIPTION
## 무슨 이유로 코드를 변경했는지

1. 프로젝트 내부 질문 데이터 무한스크롤 구현 

## 어떤 위험이나 장애가 발견되었는지

1. 질문 작성하기 문제 수정
2. 기존 useQuestionData 파일이 모달 통신 관련 로직을 같이 가지고 있어서 if(!hasNext) 코드 때문에 무한스크롤 마지막 페이지에서  질문을 작성했을 경우 추가 질문 랜더링이 되지 않았던 문제였음.
3. 또한 기존에 질문 추가 없이 모달이 끄고 켜질 때도 useQuestionData의 의존성배열에 의해 API통신이 이루어졌었는데 불필요한 부분인거 같아서 시열님과 대화 후 '질문 보내기' 버튼 동작이 이루어질 때만 API 통신 로직이 이루어지도록 수정
4. 3번 수정하면서 2번 문제도 자연스럽게 해결

5. 점심 회의 때 말한 내용대로 질문작성하기 버튼 답변페이지와 동일한 위치로 수정했습니다.
 
## 어떤 부분에 리뷰어가 집중하면 좋을지


## 관련 스크린샷
<img width="1904" alt="스크린샷 2024-01-28 오후 5 27 07" src="https://github.com/SiWooJinSeok/OpenMind6team/assets/152246452/736e210f-cf07-4ea0-bfeb-567db91e5ac6">

## 테스트 계획 또는 완료 사항

1. marge clone 후 answerPage 에도 무한스크롤 동일하게 적용