### PR TITLE
[ Docs ] PageNationNumbersContainer 스토리북 페이지네이션버튼들이 가로 일렬로 보이게 수정

### DIFF
--- a/src/components/organisms/PageNationNumbersContainer/PageNationNumbersContainer.stories.jsx
+++ b/src/components/organisms/PageNationNumbersContainer/PageNationNumbersContainer.stories.jsx
@@ -16,5 +16,9 @@ export default {
 };
 
 export function PageNationNumbersContainerStory(args) {
-  return <PageNationNumbersContainer {...args} />;
+  return (
+    <div style={{ display: 'flex' }}>
+      <PageNationNumbersContainer {...args} />
+    </div>
+  );
 }


### PR DESCRIPTION

## 무슨 이유로 코드를 변경했는지
- PageNationNumbersContainer 이 세로 일렬로 보였음

## 어떤 위험이나 장애가 발견되었는지
- X

## 어떤 부분에 리뷰어가 집중하면 좋을지
- 해당부분 스토리북 파일

## 관련 스크린샷
![image](https://github.com/SiWooJinSeok/OpenMind6team/assets/109282547/adecd61f-7bfe-4fdf-b094-1d8c38c2cdbf)

## 테스트 계획 또는 완료 사항
- X
